### PR TITLE
pass tsc + formatting

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -474,7 +474,7 @@
         "kth-digitalization-platform": "KTH Digitalisation Platform",
         "computational-support": "We receive invaluable computational support from ",
         "funding": "Funding",
-        
+
         "name-cannot-be-empty": "Name cannot be empty",
         "saving-name": "Saving name...",
         "rfc-1035-1": " must adhere to ",

--- a/src/locales/se.json
+++ b/src/locales/se.json
@@ -471,7 +471,7 @@
         "computational-support": "Vi får även stöd i form av hårdvara från ",
         "funding": "Finansiellt stöd",
         "menu-maia": "MAIA",
-        
+
         "name-cannot-be-empty": "Namnfältet är obligatoriskt",
         "saving-name": "Sparar namn...",
         "rfc-1035-1": " måste följa ",

--- a/src/pages/landing/components/funding/Funding.tsx
+++ b/src/pages/landing/components/funding/Funding.tsx
@@ -7,7 +7,6 @@ import {
   Link,
   Typography,
 } from "@mui/material";
-import Iconify from "../../../../components/Iconify";
 import { t } from "i18next";
 
 const Funding = () => {
@@ -66,7 +65,6 @@ const Funding = () => {
             </CardContent>
           </Card>
         </Grid>
-        
       </Grid>
     </Container>
   );


### PR DESCRIPTION
## Fixed `typescript` compiling and `prettier` formatting

Just ran 
```bash
bun tsc
```
and resolved an unused import
and then 
```bash
bun format
```